### PR TITLE
Create .htaccess

### DIFF
--- a/efro/.htaccess
+++ b/efro/.htaccess
@@ -1,0 +1,44 @@
+# Turn off MultiViews
+Options -MultiViews
+
+# Directive to ensure .htaccess files work
+<IfModule mod_rewrite.c>
+    RewriteEngine On
+    RewriteBase /efro/
+    
+    # Rewrite rule to serve HTML content from the vocabulary URI if requested
+    RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+    RewriteCond %{HTTP_ACCEPT} text/html [OR]
+    RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+    RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+    RewriteRule ^$ https://rgu-computing.github.io/EFRO/EFRO/docs/index-en.html [R=303,L]
+    
+    # Rewrite rule to serve RDF/XML content
+    RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+    RewriteRule ^$ https://rgu-computing.github.io/EFRO/EFRO/EFRO.rdf [R=303,L]
+    
+    # Rewrite rule to serve OWL content
+    RewriteCond %{HTTP_ACCEPT} application/owl\+xml [OR]
+    RewriteCond %{HTTP_ACCEPT} text/owl
+    RewriteRule ^$ https://rgu-computing.github.io/EFRO/EFRO/docs/ontology.owl [R=303,L]
+    
+    # Rewrite rule to serve TTL content
+    RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+    RewriteCond %{HTTP_ACCEPT} application/x-turtle
+    RewriteRule ^$ https://rgu-computing.github.io/EFRO/EFRO/docs/ontology.ttl [R=303,L]
+    
+    # Rewrite rule to serve JSON-LD content
+    RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
+    RewriteCond %{HTTP_ACCEPT} application/json
+    RewriteRule ^$ https://rgu-computing.github.io/EFRO/EFRO/docs/ontology.jsonld [R=303,L]
+    
+    # Rewrite rule to serve N-Triples content
+    RewriteCond %{HTTP_ACCEPT} application/n-triples
+    RewriteRule ^$ https://rgu-computing.github.io/EFRO/EFRO/docs/ontology.nt [R=303,L]
+    
+    # Rewrite rule for individuals
+    RewriteRule ^individuals$ https://rgu-computing.github.io/EFRO/EFRO/EFRO_individuals.rdf [R=303,L]
+    
+    # Default response: HTML
+    RewriteRule ^$ https://rgu-computing.github.io/EFRO/EFRO/docs/index-en.html [R=303,L]
+</IfModule>

--- a/efro/.htaccess
+++ b/efro/.htaccess
@@ -4,41 +4,12 @@ Options -MultiViews
 # Directive to ensure .htaccess files work
 <IfModule mod_rewrite.c>
     RewriteEngine On
-    RewriteBase /efro/
+    RewriteBase /EFRO/
     
-    # Rewrite rule to serve HTML content from the vocabulary URI if requested
-    RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
-    RewriteCond %{HTTP_ACCEPT} text/html [OR]
-    RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
-    RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-    RewriteRule ^$ https://rgu-computing.github.io/EFRO/EFRO/docs/index-en.html [R=303,L]
-    
-    # Rewrite rule to serve RDF/XML content
+    # Rewrite rule to serve RDF/XML content when requested
     RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
     RewriteRule ^$ https://rgu-computing.github.io/EFRO/EFRO/EFRO.rdf [R=303,L]
     
-    # Rewrite rule to serve OWL content
-    RewriteCond %{HTTP_ACCEPT} application/owl\+xml [OR]
-    RewriteCond %{HTTP_ACCEPT} text/owl
-    RewriteRule ^$ https://rgu-computing.github.io/EFRO/EFRO/docs/ontology.owl [R=303,L]
-    
-    # Rewrite rule to serve TTL content
-    RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
-    RewriteCond %{HTTP_ACCEPT} application/x-turtle
-    RewriteRule ^$ https://rgu-computing.github.io/EFRO/EFRO/docs/ontology.ttl [R=303,L]
-    
-    # Rewrite rule to serve JSON-LD content
-    RewriteCond %{HTTP_ACCEPT} application/ld\+json [OR]
-    RewriteCond %{HTTP_ACCEPT} application/json
-    RewriteRule ^$ https://rgu-computing.github.io/EFRO/EFRO/docs/ontology.jsonld [R=303,L]
-    
-    # Rewrite rule to serve N-Triples content
-    RewriteCond %{HTTP_ACCEPT} application/n-triples
-    RewriteRule ^$ https://rgu-computing.github.io/EFRO/EFRO/docs/ontology.nt [R=303,L]
-    
-    # Rewrite rule for individuals
-    RewriteRule ^individuals$ https://rgu-computing.github.io/EFRO/EFRO/EFRO_individuals.rdf [R=303,L]
-    
-    # Default response: HTML
+    # Default response: HTML documentation
     RewriteRule ^$ https://rgu-computing.github.io/EFRO/EFRO/docs/index-en.html [R=303,L]
 </IfModule>

--- a/efro/README.md
+++ b/efro/README.md
@@ -21,7 +21,8 @@ The EFRO ontology provides a standardised framework for modeling concepts and re
 For any questions or concerns about this ontology, please contact:
 * Umair Arshad, Robert Gordon University, Aberdeen, UK
 * Email: u.arshad1@rgu.ac.uk
-
+* 
 ## License
+This ontology is distributed under the Creative Commons Attribution 4.0 International License (CC BY 4.0).
 
-This ontology is distributed under [appropriate license CC BY 4.0
+https://creativecommons.org/licenses/by/4.0/

--- a/efro/README.md
+++ b/efro/README.md
@@ -1,4 +1,4 @@
-# EFRO Ontology
+# EFR Ontology
 
 This W3ID provides a persistent URI namespace for the EFRO (Educational Funding Regulations Ontology).
 

--- a/efro/README.md
+++ b/efro/README.md
@@ -1,10 +1,10 @@
-# EFR Ontology
+# EFRO (Educational Funding Regulations Ontology)
 
-This W3ID provides a persistent URI namespace for the EFRO (Educational Funding Regulations Ontology).
+This W3ID provides a persistent URI namespace for the EFRO.
 
 ## Ontology Details
 
-The EFRO ontology provides a standardised framework for modeling concepts and relationships within educational funding regulations. It creates a formalised vocabulary for describing funding processes, regulatory requirements, educational institutions, and financial mechanisms related to educational funding.
+The EFRO provides a standardised framework for modeling concepts and relationships within educational funding regulations. It creates a formalised vocabulary for describing funding processes, regulatory requirements, educational institutions, and financial mechanisms related to educational funding.
 
 ## Maintainers
 

--- a/efro/README.md
+++ b/efro/README.md
@@ -1,0 +1,27 @@
+# EFRO Ontology
+
+This W3ID provides a persistent URI namespace for the EFRO (Educational Funding Regulations Ontology).
+
+## Ontology Details
+
+The EFRO ontology provides a standardised framework for modeling concepts and relationships within educational funding regulations. It creates a formalised vocabulary for describing funding processes, regulatory requirements, educational institutions, and financial mechanisms related to educational funding.
+
+## Maintainers
+
+* Umair umair <u.arshad1@rgu.ac.uk>
+* GitHub Repository: https://github.com/RGU-Computing/EFRO
+
+## Links
+
+* Ontology File (RDF): https://rgu-computing.github.io/EFRO/EFRO/EFRO.rdf
+* Documentation: https://rgu-computing.github.io/EFRO/EFRO/docs/index-en.html
+
+## Contact
+
+For any questions or concerns about this ontology, please contact:
+* Umair Arshad, Robert Gordon University, Aberdeen, UK
+* Email: u.arshad1@rgu.ac.uk
+
+## License
+
+This ontology is distributed under [appropriate license, e.g., CC BY 4.0, MIT, etc.]

--- a/efro/README.md
+++ b/efro/README.md
@@ -24,4 +24,4 @@ For any questions or concerns about this ontology, please contact:
 
 ## License
 
-This ontology is distributed under [appropriate license, e.g., CC BY 4.0, MIT, etc.]
+This ontology is distributed under [appropriate license CC BY 4.0


### PR DESCRIPTION
This pull request adds the necessary files to create a persistent identifier for the EFRO (Educational Funding Regulation Ontology).

The EFRO ontology is designed to model educational funding concepts and relationships. This ontology provides a standardised vocabulary for describing educational funding regulations and compliance monitoring.

I have set up a simple redirection rule in the .htaccess file to point directly to our RDF file hosted on GitHub Pages:

- RDF file: https://rgu-computing.github.io/EFRO/EFRO/EFRO.rdf
This simplified approach provides a direct, permanent link to our ontology file. The persistent identifier will help ensure stable references to our ontology in academic publications and semantic web applications.

Our complete ontology documentation and additional formats are available at:
https://rgu-computing.github.io/EFRO/EFRO/docs/index-en.html